### PR TITLE
修复SM2加密报错，消除编译警告

### DIFF
--- a/smcrypto/Chiper.cs
+++ b/smcrypto/Chiper.cs
@@ -58,11 +58,11 @@ namespace smcrypto
             this.sm3keybase = new SM3Digest();
             this.sm3c3 = new SM3Digest();
 
-            byte[] p = byteConvert32Bytes(p2.AffineXCoord.ToBigInteger());
+            byte[] p = byteConvert32Bytes(p2.Normalize().XCoord.ToBigInteger());
             this.sm3keybase.BlockUpdate(p, 0, p.Length);
             this.sm3c3.BlockUpdate(p, 0, p.Length);
 
-            p = byteConvert32Bytes(p2.AffineYCoord.ToBigInteger());
+            p = byteConvert32Bytes(p2.Normalize().YCoord.ToBigInteger());
             this.sm3keybase.BlockUpdate(p, 0, p.Length);
             this.ct = 1;
             NextKey();
@@ -127,7 +127,7 @@ namespace smcrypto
 
         public void Dofinal(byte[] c3)
         {
-            byte[] p = byteConvert32Bytes(p2.AffineYCoord.ToBigInteger());
+            byte[] p = byteConvert32Bytes(p2.Normalize().YCoord.ToBigInteger());
             this.sm3c3.BlockUpdate(p, 0, p.Length);
             this.sm3c3.DoFinal(c3, 0);
             Reset();

--- a/smcrypto/SM2.cs
+++ b/smcrypto/SM2.cs
@@ -59,9 +59,6 @@ namespace smcrypto
         {
             ecc_param = sm2_param;
 
-            ECFieldElement ecc_gx_fieldelement;
-            ECFieldElement ecc_gy_fieldelement;
-
             ecc_p = new BigInteger(ecc_param[0], 16);
             ecc_a = new BigInteger(ecc_param[1], 16);
             ecc_b = new BigInteger(ecc_param[2], 16);
@@ -69,12 +66,8 @@ namespace smcrypto
             ecc_gx = new BigInteger(ecc_param[4], 16);
             ecc_gy = new BigInteger(ecc_param[5], 16);
 
-
-            ecc_gx_fieldelement = new FpFieldElement(ecc_p, ecc_gx);
-            ecc_gy_fieldelement = new FpFieldElement(ecc_p, ecc_gy);
-
-            ecc_curve = new FpCurve(ecc_p, ecc_a, ecc_b);
-            ecc_point_g = new FpPoint(ecc_curve, ecc_gx_fieldelement, ecc_gy_fieldelement);
+            ecc_curve = new FpCurve(ecc_p, ecc_a, ecc_b, null, null);
+            ecc_point_g = ecc_curve.CreatePoint(ecc_gx, ecc_gy);
 
             ecc_bc_spec = new ECDomainParameters(ecc_curve, ecc_point_g, ecc_n);
 

--- a/smcrypto/SM4Utils.cs
+++ b/smcrypto/SM4Utils.cs
@@ -10,7 +10,6 @@ namespace smcrypto
         public String secretKey = "";
         public String iv = "";
         public bool hexString = false;
-        public byte[] secretKeyBuff;
 
         public String Encrypt_ECB(String plainText)
         {

--- a/smcrypto/smcrypto.csproj
+++ b/smcrypto/smcrypto.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
消除编译警告，升级编译 .net core 为 2.1；
修复 SM2加密报错 System.InvalidOperationException:“point not in normal form”；